### PR TITLE
Make "Copy File -> Markdown" Action Context-Independent

### DIFF
--- a/src/main/java/com/bf/copy2md/action/CopyFileAsMarkdownAction.java
+++ b/src/main/java/com/bf/copy2md/action/CopyFileAsMarkdownAction.java
@@ -4,6 +4,7 @@ import com.bf.copy2md.formatter.MarkdownFormatter;
 import com.bf.copy2md.util.CopyUtil;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
@@ -21,175 +22,127 @@ public class CopyFileAsMarkdownAction extends AnAction {
         return ActionUpdateThread.EDT;
     }
 
-//    @Override
-//    public void update(@NotNull AnActionEvent e) {
-//        LOG.info("CopyFileAsMarkdownAction.update called");
-//
-//        // 始终设置为可见
-//        e.getPresentation().setVisible(true);
-//
-//        Project project = e.getProject();
-//        if (project == null) {
-//            LOG.info("Project is null");
-//            e.getPresentation().setEnabled(false);
-//            return;
-//        }
-//
-//        // 获取当前上下文
-//        String place = e.getPlace();
-//        LOG.info("Action place: " + place);
-//
-//        boolean enabled = false;
-//
-//        // 处理项目视图中的右键菜单
-//        if (ActionPlaces.PROJECT_VIEW_POPUP.equals(place)) {
-//            // 1. 尝试多种方式获取选中的文件
-//            VirtualFile[] files = null;
-//
-//            // 从CommonDataKeys获取
-//            files = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY);
-//            LOG.info("Trying CommonDataKeys.VIRTUAL_FILE_ARRAY: " + (files != null ? files.length : "null"));
-//
-//            // 如果上面方法失败，尝试获取PSI元素
-//            if (files == null || files.length == 0) {
-//                PsiElement[] psiElements = e.getData(LangDataKeys.PSI_ELEMENT_ARRAY);
-//                if (psiElements != null && psiElements.length > 0) {
-//                    List<VirtualFile> fileList = new ArrayList<>();
-//                    for (PsiElement element : psiElements) {
-//                        if (element instanceof PsiFile) {
-//                            VirtualFile vFile = ((PsiFile) element).getVirtualFile();
-//                            if (vFile != null) {
-//                                fileList.add(vFile);
-//                            }
-//                        }
-//                    }
-//                    if (!fileList.isEmpty()) {
-//                        files = fileList.toArray(new VirtualFile[0]);
-//                    }
-//                }
-//                LOG.info("Trying PSI_ELEMENT_ARRAY: " + (files != null ? files.length : "null"));
-//            }
-//
-//            // 尝试获取单个文件
-//            if (files == null || files.length == 0) {
-//                VirtualFile singleFile = e.getData(CommonDataKeys.VIRTUAL_FILE);
-//                if (singleFile != null) {
-//                    files = new VirtualFile[]{singleFile};
-//                }
-//                LOG.info("Trying CommonDataKeys.VIRTUAL_FILE: " + (singleFile != null));
-//            }
-//
-//            // 检查获取到的文件
-//            if (files != null && files.length > 0) {
-//                LOG.info("Found " + files.length + " files");
-//                for (VirtualFile file : files) {
-//                    if (file != null) {
-//                        LOG.info("Processing file: " + file.getPath() +
-//                                ", isDirectory: " + file.isDirectory() +
-//                                ", exists: " + file.exists());
-//                        if (!file.isDirectory()) {
-//                            enabled = true;
-//                            break;
-//                        }
-//                    }
-//                }
-//            } else {
-//                LOG.info("No files found in project view");
-//            }
-//        }
-//        // 处理编辑器中的右键菜单
-//        else if (ActionPlaces.EDITOR_POPUP.equals(place)) {
-//            Editor editor = e.getData(CommonDataKeys.EDITOR);
-//            VirtualFile file = null;
-//            if (editor != null) {
-//                file = FileDocumentManager.getInstance().getFile(editor.getDocument());
-//            }
-//            if (file == null) {
-//                file = e.getData(CommonDataKeys.VIRTUAL_FILE);
-//            }
-//
-//            LOG.info("Editor popup - Editor: " + (editor != null));
-//            LOG.info("Editor popup - VirtualFile: " + (file != null ? file.getPath() : "null"));
-//
-//            enabled = file != null;
-//        }
-//        // 处理编辑器标签页的右键菜单
-//        else if (ActionPlaces.EDITOR_TAB_POPUP.equals(place)) {
-//            VirtualFile file = e.getData(CommonDataKeys.VIRTUAL_FILE);
-//            LOG.info("Editor tab file: " + (file != null ? file.getPath() : "null"));
-//            enabled = file != null;
-//        }
-//
-//        // 设置菜单项状态
-//        e.getPresentation().setEnabled(enabled);
-//        LOG.info("Menu item enabled: " + enabled);
-//    }
-
     @Override
-    public void actionPerformed(@NotNull AnActionEvent e) {
-        LOG.info("CopyFileAsMarkdownAction.actionPerformed called");
-
-        Project project = e.getRequiredData(CommonDataKeys.PROJECT);
-        List<VirtualFile> filesToProcess = new ArrayList<>();
-
-        // 获取当前上下文
-        String place = e.getPlace();
-
-        // 根据不同上下文获取目标文件
-        if (ActionPlaces.PROJECT_VIEW_POPUP.equals(place)) {
-            // 处理项目视图中选中的多个文件
-            VirtualFile[] selectedFiles = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY);
-            if (selectedFiles != null) {
-                for (VirtualFile file : selectedFiles) {
-                    if (!file.isDirectory()) {
-                        filesToProcess.add(file);
-                        LOG.info("Added file to process: " + file.getPath());
-                    } else {
-                        LOG.info("Skipped directory: " + file.getPath());
-                    }
-                }
-            }
-        } else if (ActionPlaces.EDITOR_POPUP.equals(place)) {
-            // 处理编辑器中的当前文件
-            VirtualFile file = e.getData(CommonDataKeys.VIRTUAL_FILE);
-            if (file != null) {
-                filesToProcess.add(file);
-                LOG.info("Added current editor file: " + file.getPath());
-            }
-        } else if (ActionPlaces.EDITOR_TAB_POPUP.equals(place)) {
-            // 处理编辑器标签页的文件
-            VirtualFile file = e.getData(CommonDataKeys.VIRTUAL_FILE);
-            if (file != null && !file.isDirectory()) {
-                filesToProcess.add(file);
-                LOG.info("Added editor tab file: " + file.getPath());
-            }
-        }
-
-        if (filesToProcess.isEmpty()) {
-            LOG.warn("No files to process");
+    public void update(@NotNull AnActionEvent e) {
+        Project project = e.getProject();
+        if (project == null) {
+            e.getPresentation().setEnabledAndVisible(false);
             return;
         }
-
+    
+        boolean hasFiles = false;
+        // Check for multiple files (Project View context)
+        VirtualFile[] filesArray = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY);
+        if (filesArray != null) {
+            for (VirtualFile vf : filesArray) {
+                // Ensure at least one non-directory file is selected
+                if (vf != null && !vf.isDirectory()) {
+                    hasFiles = true;
+                    break;
+                }
+            }
+        }
+    
+        // If no array, check for single file (Editor, Tab context)
+        if (!hasFiles) {
+            VirtualFile singleFile = e.getData(CommonDataKeys.VIRTUAL_FILE);
+            if (singleFile != null && !singleFile.isDirectory()) {
+                hasFiles = true;
+            }
+        }
+    
+        // You could potentially add a check for the editor's current file
+        // even if VIRTUAL_FILE isn't directly available in the event data
+        // Editor editor = e.getData(CommonDataKeys.EDITOR);
+        // if (!hasFiles && editor != null) {
+        //    VirtualFile fileFromDoc = FileDocumentManager.getInstance().getFile(editor.getDocument());
+        //    if (fileFromDoc != null && !fileFromDoc.isDirectory()) {
+        //        hasFiles = true;
+        //    }
+        // }
+    
+        e.getPresentation().setEnabledAndVisible(hasFiles);
+        // Use logging during development:
+        // LOG.info("CopyFileAsMarkdownAction.update - Place: " + e.getPlace() + ", Enabled: " + hasFiles);
+    }
+    
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        LOG.info("CopyFileAsMarkdownAction.actionPerformed called. Place: " + e.getPlace());
+    
+        Project project = e.getRequiredData(CommonDataKeys.PROJECT);
+        List<VirtualFile> filesToProcess = new ArrayList<>();
+    
+        // 1. Try getting an array of files (most common in Project View)
+        VirtualFile[] selectedFiles = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY);
+        if (selectedFiles != null && selectedFiles.length > 0) {
+            LOG.info("Processing VIRTUAL_FILE_ARRAY with " + selectedFiles.length + " items.");
+            for (VirtualFile file : selectedFiles) {
+                if (file != null && !file.isDirectory()) {
+                    filesToProcess.add(file);
+                    LOG.info("Added file from array: " + file.getPath());
+                } else {
+                    LOG.info("Skipped item from array (null or directory): " + (file != null ? file.getPath() : "null"));
+                }
+            }
+        }
+    
+        // 2. If no array, try getting a single file (common in Editor, Tabs, or single selection in Project View)
+        if (filesToProcess.isEmpty()) {
+            VirtualFile singleFile = e.getData(CommonDataKeys.VIRTUAL_FILE);
+            if (singleFile != null && !singleFile.isDirectory()) {
+                LOG.info("Processing single VIRTUAL_FILE: " + singleFile.getPath());
+                filesToProcess.add(singleFile);
+            } else {
+                 LOG.info("VIRTUAL_FILE was null or a directory.");
+                 // Optional: Try getting file from editor context as a fallback
+                 Editor editor = e.getData(CommonDataKeys.EDITOR);
+                 if (editor != null) {
+                     VirtualFile fileFromDoc = com.intellij.openapi.fileEditor.FileDocumentManager.getInstance().getFile(editor.getDocument());
+                     if (fileFromDoc != null && !fileFromDoc.isDirectory()) {
+                         LOG.info("Processing file from editor document: " + fileFromDoc.getPath());
+                         filesToProcess.add(fileFromDoc);
+                     }
+                 }
+            }
+        }
+    
+    
+        if (filesToProcess.isEmpty()) {
+            LOG.warn("No files to process after checking all sources.");
+            CopyUtil.showErrorHint(project, "No file context found for copying.");
+            return;
+        }
+    
+        // --- Rest of your processing logic ---
         try {
             StringBuilder markdown = new StringBuilder();
             markdown.append("# Project Name: ").append(project.getName()).append("\n\n");
-
+    
             for (VirtualFile file : filesToProcess) {
                 LOG.info("Processing file: " + file.getPath());
                 try {
                     String content = new String(file.contentsToByteArray(), StandardCharsets.UTF_8);
                     markdown.append(formatter.formatFileContent(project, file, content));
-                    markdown.append("\n\n");
+                    markdown.append("\n\n"); // Keep separation between files
                 } catch (Exception ex) {
-                    LOG.warn("Error processing file: " + file.getPath() + ", error: " + ex.getMessage());
+                    LOG.warn("Error processing file: " + file.getPath() + ", error: " + ex.getMessage(), ex);
                     CopyUtil.showErrorHint(project, "Error reading file: " + file.getName());
                 }
             }
-
-            CopyUtil.copyToClipboardWithNotification(markdown.toString(), project);
-            LOG.info("Successfully copied " + filesToProcess.size() + " files to clipboard");
+    
+            // Remove trailing newlines if any
+            String resultMarkdown = markdown.toString().trim();
+            if (!resultMarkdown.isEmpty()) {
+                 CopyUtil.copyToClipboardWithNotification(resultMarkdown, project);
+                 LOG.info("Successfully copied " + filesToProcess.size() + " files to clipboard");
+            } else {
+                 LOG.warn("Resulting markdown was empty.");
+                 CopyUtil.showErrorHint(project, "No content generated for copying.");
+            }
+    
         } catch (Exception ex) {
-            LOG.warn("Error in actionPerformed: " + ex.getMessage());
+            LOG.warn("Error in actionPerformed: " + ex.getMessage(), ex);
             CopyUtil.showErrorHint(project, "Error copying files: " + ex.getMessage());
         }
     }


### PR DESCRIPTION
The "Copy File as Markdown" action previously only worked reliably when invoked via right-click context menus (Project View, Editor, Tab). Triggering it via keyboard shortcuts or the command palette often failed because the action couldn't determine the target file(s) without the specific menu context (`ActionPlace`).

This change refactors the action (`CopyFileAsMarkdownAction`) to:

1.  Correctly identify the target file(s) by directly checking for relevant data (`CommonDataKeys.VIRTUAL_FILE_ARRAY`, `CommonDataKeys.VIRTUAL_FILE`, editor context) in the `AnActionEvent`, regardless of how the action was invoked.
2.  Properly implement the `update` method to enable/disable the action based on the presence of a valid file context, ensuring it's only available when appropriate.

Users can now consistently use "Copy File as Markdown" via keyboard shortcuts, the command palette ("Find Action"), or context menus.